### PR TITLE
Fix for binding to header property when defining radium-datagrid-column.

### DIFF
--- a/radium-datagrid.html
+++ b/radium-datagrid.html
@@ -494,6 +494,9 @@ column.
         if (e.detail.prop === 'columnWidth') {
           this._columnWidths = {};
         }
+        if (e.detail.prop === 'header') {
+          this.set('_headers.' + detail.index + '.config.header', e.target.header);
+        }
         this.$.headerRow.children[detail.index][detail.prop] = e.target[detail.prop];
       },
       _computedTranslate: function(i18n, key, defaultVal) {


### PR DESCRIPTION
Bindings to a `radium-datagrid-column` fail to update the UI.

For example:

``` html
<radium-datagrid-column header="[[xlate('NAME')]]" ...>
```

will fail to render a header value (even though the corresponding `radium-datagrid-column` is populated with the computed `header` value).

With bindings, the `header` value is computed after the component is ready. The `_handleHeaderUpdate()` in `radium-datagrid` which listens for changes from the `header` property dispatched by `radium-datagrid-column` does successfully fire and update the property on the `radium-datagrid-column` instance. However, this has no effect because the `headerRow` template renders from the private `_headers[n].config.header` in `radium-datagrid` rather than the `radium-datagrid-column` instance's `header` property.

I tweaked `_handleHeaderUpdate()` to also update the internal `_headers[n].config.header` property when handling a `header` property update.
